### PR TITLE
i256: Fix logical errors in doc comments for is_negative and is_zero

### DIFF
--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -265,13 +265,13 @@ impl I256 {
     }
 
     /// Returns `true` if `self` is negative and `false` if the number is zero
-    /// or negative.
+    /// or positive.
     #[inline(always)]
     pub const fn is_negative(self) -> bool {
         self.signum64().is_negative()
     }
 
-    /// Returns `true` if `self` is negative and `false` if the number is zero
+    /// Returns `true` if `self` is zero and `false` if the number is negative
     /// or positive.
     #[inline(always)]
     pub const fn is_zero(self) -> bool {


### PR DESCRIPTION
This should be less confusing ;)